### PR TITLE
Make Dispose method of Wrapped Observable Collection virtual

### DIFF
--- a/SByteDev.MvvmCross.Extensions/SByteDev.MvvmCross.Extensions/WrappedObservableCollection.cs
+++ b/SByteDev.MvvmCross.Extensions/SByteDev.MvvmCross.Extensions/WrappedObservableCollection.cs
@@ -220,7 +220,7 @@ namespace SByteDev.MvvmCross.Extensions
             return _items.GetEnumerator();
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             Clear();
 


### PR DESCRIPTION
Inheritors of the `WrappedObservableCollection` should have a possibility to expand the disposing behaviour, thus we need to make the `Dispose` method virtual.